### PR TITLE
fix(jupiter): auto-remount USB mass storage après déconnexion

### DIFF
--- a/hosts/jupiter/hardware-configuration.nix
+++ b/hosts/jupiter/hardware-configuration.nix
@@ -15,6 +15,7 @@
   boot.initrd.kernelModules = [];
   boot.kernelModules = ["kvm-amd"];
   boot.extraModulePackages = [];
+  boot.kernelParams = ["usbcore.autosuspend=-1"];
 
   fileSystems."/" = {
     device = "/dev/disk/by-uuid/55e6a024-d3a6-4827-b734-32f80119284e";
@@ -31,6 +32,14 @@
     fsType = "ext4";
     options = ["nofail" "defaults"];
   };
+
+  # Auto-remount the USB mass storage when it reconnects after a glitch
+  # (e.g. kernel renames sda → sdb). Without this udev rule the mount
+  # goes stale and returns EIO until a manual umount + mount.
+  services.udev.extraRules = ''
+    ACTION=="add", SUBSYSTEM=="block", ENV{ID_FS_UUID}=="e59ec576-6efd-4f7f-bd91-b39b6b16ee46", \
+      RUN+="/run/current-system/sw/bin/systemctl --no-block restart mnt-mass.mount"
+  '';
 
   swapDevices = [];
 


### PR DESCRIPTION
## Problème

Le boîtier USB 16 To (`/mnt/mass`, UUID `e59ec576`) se déconnecte parfois, le kernel le renomme (`sda` → `sdb`), et le mount devient fantôme : toute tentative d'accès renvoie `EIO (os error 5)`.

```
EXT4-fs warning (device sda1): htree_dirblock_to_tree:1083: inode #75235423: lblock 0: 
comm Sonarr: error -5 reading directory block
```

## Solution

Deux changements dans `hardware-configuration.nix` :

1. **`boot.kernelParams = ["usbcore.autosuspend=-1"]`** — empêche le kernel d'endormir le disque USB (préventif)

2. **Règle udev** — quand le disque réapparaît, `systemctl restart mnt-mass.mount` force le démontage du fantôme et le remontage avec le bon `/dev/sdX` (curatif)

```nix
services.udev.extraRules = ''
  ACTION=="add", SUBSYSTEM=="block", ENV{ID_FS_UUID}=="e59ec576-6efd-4f7f-bd91-b39b6b16ee46", \
    RUN+="/run/current-system/sw/bin/systemctl --no-block restart mnt-mass.mount"
'';
```